### PR TITLE
feat: allow configuring in which network instances are created

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ The following parameters are supported:
 | `image`          | string | Image (slug) of virtual machine, [more information](https://www.cloudscale.ch/en/api/v1#images)                 |
 | `volume_size_gb` | number | The size of the root volume in GiB. Must be at least `10`.                                                      |
 | `user_data`      | string | Depending on the image choice is either in the format of cloud-init (YAML) or Ignition (JSON).                  |
-| `network`        | string | The network to attach to the machines. Defaults to `public`                                                     |
+| `network`        | string | The primary network to attach to the machines. Defaults to `public`. You need to ensure the runner controller can reach the machines via this one.                                                      |
+| `extra_networks` | string | Additional networks to be added to the machines.                                                                |
 
 ### Default connector config
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ The following parameters are supported:
 | `image`          | string | Image (slug) of virtual machine, [more information](https://www.cloudscale.ch/en/api/v1#images)                 |
 | `volume_size_gb` | number | The size of the root volume in GiB. Must be at least `10`.                                                      |
 | `user_data`      | string | Depending on the image choice is either in the format of cloud-init (YAML) or Ignition (JSON).                  |
-| `network`        | string | The primary network to attach to the machines. Defaults to `public`. You need to ensure the runner controller can reach the machines via this one.                                                      |
-| `extra_networks` | string | Additional networks to be added to the machines.                                                                |
+| `interfaces`     | object | Describes the interfaces to attach to the instances. Check the config template for some examples.               |
 
 ### Default connector config
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A [fleeting](https://docs.gitlab.com/runner/fleet_scaling/fleeting/) plugin for 
 
 ### Caveats
 
-- 🔒 Private networks are not yet supported.
 - ⬇️ Stopped runner instances are automatically removed and recycled.
 
 ## 🏎️ Demo and Ansible Playbook
@@ -141,6 +140,7 @@ The following parameters are supported:
 | `image`          | string | Image (slug) of virtual machine, [more information](https://www.cloudscale.ch/en/api/v1#images)                 |
 | `volume_size_gb` | number | The size of the root volume in GiB. Must be at least `10`.                                                      |
 | `user_data`      | string | Depending on the image choice is either in the format of cloud-init (YAML) or Ignition (JSON).                  |
+| `network`        | string | The network to attach to the machines. Defaults to `public`                                                     |
 
 ### Default connector config
 

--- a/config/config.toml.template
+++ b/config/config.toml.template
@@ -96,14 +96,21 @@ concurrent = 40
   # The root disk size of each instance.
   volume_size_gb = 25
 
-  # The primary network. You need to ensure that the runner manager can
-  # access your instances on this one.
-  network = "public"
-  
-  # Additional networks to connect to the machine.
-  # extra_networks = [
-  #  "b10742ba-6949-44fd-9387-74fa7ac65854",
-  #  "618baa7b-3185-470c-b230-32ff34ddfd72"
+  # Networking configuration for the instances
+  # The Network that is listed first will be used for the communication with the runner controller.
+  # This direcly mirrors the go sdk types (https://github.com/cloudscale-ch/cloudscale-go-sdk/blob/1baae3ab99a83a25221c77a8c6f4c69838979312/servers.go#L116-L124)
+  # interfaces = [
+  #   { network = "UUID3"},
+  #   { network = "UUID3"},
+  # ]
+  #
+  # Only one interface in the public network.
+  # This is also the default if nothing is set
+  interfaces = [{ network = "public" }]
+  # Two interfaces, one in a private network
+  # interfaces = [
+  #   { network = "public" },
+  #   { network = "uuid of private net"},
   # ]
 
   # The cloud-config applied to each instance. Note that GitLab expects these

--- a/config/config.toml.template
+++ b/config/config.toml.template
@@ -96,8 +96,15 @@ concurrent = 40
   # The root disk size of each instance.
   volume_size_gb = 25
 
-  # Create the instances in a private network, instead of the default public one.
-  # network = "90b7d32b-1400-4d78-95ef-5c4aa9aaab7b"
+  # The primary network. You need to ensure that the runner manager can
+  # access your instances on this one.
+  network = "public"
+  
+  # Additional networks to connect to the machine.
+  # extra_networks = [
+  #  "b10742ba-6949-44fd-9387-74fa7ac65854",
+  #  "618baa7b-3185-470c-b230-32ff34ddfd72"
+  # ]
 
   # The cloud-config applied to each instance. Note that GitLab expects these
   # instances to have a running docker daemon.

--- a/config/config.toml.template
+++ b/config/config.toml.template
@@ -96,6 +96,9 @@ concurrent = 40
   # The root disk size of each instance.
   volume_size_gb = 25
 
+  # Create the instances in a private network, instead of the default public one.
+  # network = "90b7d32b-1400-4d78-95ef-5c4aa9aaab7b"
+
   # The cloud-config applied to each instance. Note that GitLab expects these
   # instances to have a running docker daemon.
   user_data = """#cloud-config

--- a/provider.go
+++ b/provider.go
@@ -37,8 +37,10 @@ type InstanceGroup struct {
 	Zone     string `json:"zone"`
 	Flavor   string `json:"flavor"`
 	Image    string `json:"image"`
-	Network  string `json:"network,omitempty"`
 	UserData string `json:"user_data"`
+
+	Network  string `json:"network,omitempty"`
+	ExtraNetworks  []string `json:"extra_networks,omitempty"`
 
 	VolumeSizeGB int `json:"volume_size_gb,omitempty"`
 
@@ -203,10 +205,6 @@ func (g *InstanceGroup) Init(
 		g.settings.Username = "root"
 	}
 
-	if g.Network == "" {
-		g.Network = "public"
-	}
-
 	// Validate config
 	if err := g.validate(); err != nil {
 		return provider.ProviderInfo{}, fmt.Errorf(
@@ -292,9 +290,6 @@ func (g *InstanceGroup) Increase(
 	ctx context.Context,
 	delta int,
 ) (succeeded int, err error) {
-	servers := make([]*cloudscale.Server, 0, delta)
-	errs := make([]error, 0)
-
 	publicKey, err := g.publicKey()
 	if err != nil {
 		return 0, err

--- a/provider.go
+++ b/provider.go
@@ -39,8 +39,7 @@ type InstanceGroup struct {
 	Image    string `json:"image"`
 	UserData string `json:"user_data"`
 
-	Network  string `json:"network,omitempty"`
-	ExtraNetworks  []string `json:"extra_networks,omitempty"`
+	Interfaces []cloudscale.InterfaceRequest `json:"interfaces,omitempty"`
 
 	VolumeSizeGB int `json:"volume_size_gb,omitempty"`
 
@@ -117,6 +116,14 @@ func (g *InstanceGroup) validate() error {
 
 	if g.Zone != "" && g.Zone != "rma1" && g.Zone != "lpg1" {
 		err("plugin_config: zone %s should be rma1 or lpg1", g.Zone)
+	}
+
+	if g.Interfaces == nil {
+		g.Interfaces = []cloudscale.InterfaceRequest{
+			cloudscale.InterfaceRequest{
+				Network: "public",
+			},
+		}
 	}
 
 	if g.VolumeSizeGB < 10 {

--- a/provider.go
+++ b/provider.go
@@ -37,6 +37,7 @@ type InstanceGroup struct {
 	Zone     string `json:"zone"`
 	Flavor   string `json:"flavor"`
 	Image    string `json:"image"`
+	Network  string `json:"network,omitempty"`
 	UserData string `json:"user_data"`
 
 	VolumeSizeGB int `json:"volume_size_gb,omitempty"`
@@ -202,6 +203,10 @@ func (g *InstanceGroup) Init(
 		g.settings.Username = "root"
 	}
 
+	if g.Network == "" {
+		g.Network = "public"
+	}
+
 	// Validate config
 	if err := g.validate(); err != nil {
 		return provider.ProviderInfo{}, fmt.Errorf(
@@ -309,6 +314,9 @@ func (g *InstanceGroup) Increase(
 			SSHKeys:      []string{string(publicKey)},
 			VolumeSizeGB: g.VolumeSizeGB,
 			UserData:     g.UserData,
+			Interfaces:   &[]cloudscale.InterfaceRequest{
+								cloudscale.InterfaceRequest{Network: g.Network},
+							},
 			TaggedResourceRequest: cloudscale.TaggedResourceRequest{
 				Tags: &tagMap,
 			},


### PR DESCRIPTION
For our usecase, we needed the runner instances to be created in a private network.

If no network is specified, will use the public by default